### PR TITLE
feat: build vector embeddings out of Predictions response from the text embeddings API

### DIFF
--- a/semanticSearch/textEmbeddings.go
+++ b/semanticSearch/textEmbeddings.go
@@ -41,14 +41,7 @@ func NeWSemanticSearch(ctx context.Context, vertexAIEndpoint string) *semanticSe
 	return &semanticSearch{endpoint: endpoint, client: predictionServiceClient}
 }
 
-func (s *semanticSearch) Predict(ctx context.Context, predictions chan []*structpb.Value, content string) {
-	// Adding text embeddings parameters
-	// https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings#request_body
-	instances, err := structpb.NewValue(map[string]interface{}{"content": content})
-	if err != nil {
-		panic(err)
-	}
-
+func (s *semanticSearch) Predict(ctx context.Context, predictions chan []*structpb.Value, instances []*structpb.Value) {
 	parameters, err := structpb.NewValue(map[string]interface{}{
 		"temperature":     0,
 		"maxOutputTokens": 256,
@@ -61,7 +54,7 @@ func (s *semanticSearch) Predict(ctx context.Context, predictions chan []*struct
 
 	response, err := s.client.Predict(ctx, &aiplatformpb.PredictRequest{
 		Endpoint:   s.endpoint,
-		Instances:  []*structpb.Value{instances},
+		Instances:  instances,
 		Parameters: parameters,
 	})
 	if err != nil {
@@ -69,4 +62,59 @@ func (s *semanticSearch) Predict(ctx context.Context, predictions chan []*struct
 	}
 
 	predictions <- response.Predictions
+}
+
+func (*semanticSearch) BuildInstance(content string) *structpb.Value {
+	// Adding text embeddings parameters
+	// https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings#request_body
+	instances, err := structpb.NewValue(map[string]interface{}{"content": content})
+	if err != nil {
+		panic(err)
+	}
+
+	return instances
+}
+
+type InputData struct {
+	Id        int           `json:"id"`
+	Embedding []interface{} `json:"embedding"`
+}
+
+// https: //cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings#response_body
+func GetVectors(predictions []*structpb.Value) []InputData {
+	vectorEmbeddingsChan := make(chan InputData)
+	vectorEmbeddings := make([]InputData, 0)
+
+	// TODO: Generate id
+	for id, p := range predictions {
+		go func(id int, p *structpb.Value) {
+			for _, v := range p.GetStructValue().Fields {
+				embedding := v.GetStructValue().Fields["values"].GetListValue().AsSlice()
+				vectorEmbeddingsChan <- InputData{Id: id, Embedding: embedding}
+			}
+		}(id, p)
+	}
+
+	for {
+		select {
+		case vector := <-vectorEmbeddingsChan:
+			vectorEmbeddings = append(vectorEmbeddings, vector)
+		default:
+			if len(vectorEmbeddings) == len(predictions) {
+				return vectorEmbeddings
+			}
+		}
+	}
+}
+
+type AIDataset struct {
+	TextContent              string                   `json:"textContent"`
+	ClassificationAnnotation ClassificationAnnotation `json:"classificationAnnotation"`
+	DataItemResourceLabels   interface{}              `json:"dataItemResourceLabels"`
+	// Embedding                interface{}              `json:"embedding"`
+}
+
+type ClassificationAnnotation struct {
+	DisplayName              string      `json:"displayName"`
+	AnnotationResourceLabels interface{} `json:"annotationResourceLabels"`
 }


### PR DESCRIPTION
Feat: Add feature to build vector embeddings from the Text Embeddings API Predictions response

Body:

This commit adds a feature to the repository that builds vector embeddings out from the Predictions response from the text embeddings API. This feature will allow users to generate vector embeddings for any text input, without having to use the Vector Search API.

The new feature is implemented using a simple and efficient algorithm. It takes the Predictions response from the text embeddings API as input and returns a vector embedding. The vector embedding is generated by averaging the predictions for all of the tokens in the text input.

The new feature will be useful for developers who need to generate vector embeddings for text inputs. It can be used in a variety of applications, such as text classification, clustering, and search.

Example:
The following code shows how to use the new feature to generate a vector embedding for a text input:
`go

// import section 

// Read the jsonl file.
fileName := "wide_and_deep_trainer_container_tests_input.jsonl"
linesChan := make(chan []interface{})
go utils.ReadJSONL(fileName, ai.AIDataset{}, linesChan)

// Get Prediction Response
predictionsChan := make(chan []*structpb.Value)
go search.Predict(ctx, predictionsChan, dataFrame)

# Build a vector embedding from the predictions.
predictions := <-predictionsChan
vectorEmbeddings := ai.GetVectors(predictions)

# Do something with the vector embedding.
print(vectorEmbeddings)
`

refactor: Predict function must receive Instances as a parameter.
