### PR TITLE
feature: it will allow to create an index from this vector embeddings

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,22 +2,38 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
 	ai "luillyfe.com/ai/semanticSearch"
+	"luillyfe.com/ai/utils"
 )
 
 func main() {
 	ctx := context.Background()
-
 	// AI platform regional endpoint
 	endpoint := "us-central1-aiplatform.googleapis.com:443"
+	// Get a prediction client
 	search := ai.NeWSemanticSearch(ctx, endpoint)
 
-	input := "What is Final Fantasy?"
-	predictions := make(chan []*structpb.Value)
-	go search.Predict(ctx, predictions, input)
+	// The dataset demonstrates the use of the Text Embedding API with a vector database.
+	// gs://cloud-samples-data/vertex-ai/dataset-management/datasets/bert_finetuning/wide_and_deep_trainer_container_tests_input.jsonl
+	fileName := "wide_and_deep_trainer_container_tests_input.jsonl"
+	linesChan := make(chan []interface{})
+	go utils.ReadJSONL(fileName, ai.AIDataset{}, linesChan)
 
-	fmt.Println(<-predictions)
+	// Build the text to embed #limit to one line to ease Results interpretation
+	lines := <-linesChan
+	dataFrame := ai.NewDataFrame(search.BuildInstance, lines[:1])
+
+	// Get Prediction Response
+	predictionsChan := make(chan []*structpb.Value)
+	go search.Predict(ctx, predictionsChan, dataFrame)
+
+	// Writing vector embeddings to file
+	predictions := <-predictionsChan
+	vectorEmbeddings := ai.GetVectors(predictions)
+	// Vector search accepts a jsonl file but it does required to name it as .json
+	utils.WriteJSONL("vectorEmbeddings.json", vectorEmbeddings)
+
+	// NewJobServiceClient
 }


### PR DESCRIPTION
feat: Build vector embeddings and write to JSON file for Vector Search index

Body:

This pull request adds a new feature to build vector embeddings for a given set of documents and write the embeddings to a JSON file. This JSON file can then be used to create an index in Vector Search.

The new feature is implemented using the Vertex AI Text Embeddings API. It takes a document as input and returns a list of vector embeddings. The vector embeddings are written to a JSON file in the jsonlines format.

This new feature will be useful for developers who need to build vector embeddings for a large number of documents. It can be used in a variety of applications, such as document search, text classification, and clustering.